### PR TITLE
docs: remove checks badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![checks](https://github.com/martoc/action-container-distribute/actions/workflows/checks.yml/badge.svg?branch=main&event=push)](https://github.com/martoc/action-container-distribute/actions/workflows/checks.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 # action-container-distribute


### PR DESCRIPTION
## Summary
- Remove checks badge from README, keeping only the license badge for cleaner presentation