### PR TITLE
feat: add AWS ECR support with automatic repository creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Claude Code Instructions
+
+## Project Overview
+
+This is a GitHub Action that copies container images between registries. It supports:
+
+- **GCP Artifact Registry**: Using Workload Identity Federation for authentication
+- **AWS ECR**: Using OIDC authentication with IAM role assumption
+
+## Key Files
+
+- `action.yml` - Main action definition (composite action)
+- `scripts/ecr-ensure-repository.sh` - Script to create ECR repositories if they don't exist
+- `docs/USAGE.md` - Detailed usage documentation
+- `docs/CODESTYLE.md` - Code style guidelines
+
+## Development Guidelines
+
+### Testing Changes
+
+This is a composite GitHub Action, so testing requires:
+
+1. Push changes to a branch
+2. Reference the branch in a workflow
+3. Run the workflow to test
+
+### Code Style
+
+- Follow yamllint configuration in `.yamllint`
+- Use British English in code, comments, and documentation
+- Shell scripts must use strict mode (`set -euo pipefail`)
+
+### Supported Registry Combinations
+
+| Source | Target | Status |
+|--------|--------|--------|
+| GCP    | GCP    | Supported |
+| GCP    | AWS    | Supported |
+| AWS    | AWS    | Supported |
+| AWS    | GCP    | Not yet implemented |
+
+### AWS ECR Notes
+
+- ECR requires repositories to exist before pushing images
+- The `scripts/ecr-ensure-repository.sh` script handles automatic repository creation
+- ECR image scanning on push is deprecated and should not be enabled
+
+### Adding New Registry Support
+
+To add support for a new registry:
+
+1. Add input parameters to `action.yml` (both source and target)
+2. Add authentication step using appropriate GitHub Action
+3. Add pull step with registry-specific login
+4. Add push step with registry-specific login and image URI format
+5. Update documentation in `docs/USAGE.md` and `README.md`

--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 # action-container-distribute
 
-A GitHub Action that copies container images between registries. Currently supports GCP Artifact Registry for both source and target registries.
+A GitHub Action that copies container images between registries. Supports GCP Artifact Registry and AWS ECR.
 
 ## Features
 
 - Copy container images between GCP Artifact Registry instances
-- Workload Identity Federation support for secure authentication
-- Cross-region and cross-project image distribution
+- Copy container images between AWS ECR registries
+- Cross-cloud migration: GCP to AWS ECR
+- Workload Identity Federation support for GCP authentication
+- OIDC authentication for AWS
+- Automatic ECR repository creation when pushing to AWS
 
 ## Quick Start
+
+### GCP to GCP
 
 ```yaml
 - name: Distribute container image
@@ -29,6 +34,24 @@ A GitHub Action that copies container images between registries. Currently suppo
     container_image: namespace/image:tag
 ```
 
+### GCP to AWS ECR
+
+```yaml
+- name: Distribute container image to AWS
+  uses: martoc/action-container-distribute@v1
+  with:
+    source_registry: gcp
+    source_workload_identity_provider: ${{ secrets.SOURCE_WIF_PROVIDER }}
+    source_service_account: ${{ secrets.SOURCE_SERVICE_ACCOUNT }}
+    source_region: europe-west2
+    source_gcp_project_id: source-project
+    target_registry: aws
+    target_aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+    target_region: eu-west-1
+    target_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+    container_image: namespace/image:tag
+```
+
 ## Documentation
 
 - [Usage Guide](./docs/USAGE.md) - Detailed usage instructions and examples
@@ -38,16 +61,20 @@ A GitHub Action that copies container images between registries. Currently suppo
 
 | Input | Description | Required |
 |-------|-------------|----------|
-| `source_registry` | Source registry (e.g., `gcp`) | Yes |
-| `source_workload_identity_provider` | Source Workload Identity Provider | No |
-| `source_service_account` | Source Service Account | No |
+| `source_registry` | Source registry (`gcp` or `aws`) | Yes |
+| `source_workload_identity_provider` | GCP Workload Identity Provider | No |
+| `source_service_account` | GCP Service Account | No |
 | `source_region` | Source region | No |
 | `source_gcp_project_id` | Source GCP Project ID | No |
-| `target_registry` | Target registry (e.g., `gcp`) | Yes |
-| `target_workload_identity_provider` | Target Workload Identity Provider | No |
-| `target_service_account` | Target Service Account | No |
+| `source_aws_account_id` | Source AWS Account ID | No |
+| `source_aws_role_arn` | Source AWS IAM Role ARN for OIDC | No |
+| `target_registry` | Target registry (`gcp` or `aws`) | Yes |
+| `target_workload_identity_provider` | GCP Workload Identity Provider | No |
+| `target_service_account` | GCP Service Account | No |
 | `target_region` | Target region | No |
 | `target_gcp_project_id` | Target GCP Project ID | No |
+| `target_aws_account_id` | Target AWS Account ID | No |
+| `target_aws_role_arn` | Target AWS IAM Role ARN for OIDC | No |
 | `container_image` | Container image in format `[namespace]/[name]:[tag]` | Yes |
 
 ## Licence

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: "Google Cloud Project ID"
     required: false
     default: ""
+  source_aws_account_id:
+    description: "AWS Account ID"
+    required: false
+    default: ""
+  source_aws_role_arn:
+    description: "AWS IAM Role ARN for OIDC authentication"
+    required: false
+    default: ""
   target_registry:
     description: "Target registry"
     required: true
@@ -40,6 +48,14 @@ inputs:
     default: ""
   target_gcp_project_id:
     description: "Google Cloud Project ID"
+    required: false
+    default: ""
+  target_aws_account_id:
+    description: "AWS Account ID"
+    required: false
+    default: ""
+  target_aws_role_arn:
+    description: "AWS IAM Role ARN for OIDC authentication"
     required: false
     default: ""
   container_image:
@@ -64,16 +80,59 @@ runs:
         gcloud auth configure-docker --quiet ${{ inputs.source_region }}-docker.pkg.dev
         docker pull ${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }}
       if: ${{ inputs.source_registry == 'gcp' }}
+    - name: Configure AWS credentials for source
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.source_aws_role_arn }}
+        aws-region: ${{ inputs.source_region }}
+      if: ${{ inputs.source_registry == 'aws' }}
+    - name: Pull image from AWS ECR source
+      shell: bash
+      run: |
+        aws ecr get-login-password --region ${{ inputs.source_region }} | \
+          docker login --username AWS --password-stdin ${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com
+        docker pull ${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}
+      if: ${{ inputs.source_registry == 'aws' }}
     - uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: ${{ inputs.target_workload_identity_provider }}
         service_account: ${{ inputs.target_service_account }}
       if: ${{ inputs.target_registry == 'gcp' }}
-    - name: Push image to target
+    - name: Push image to GCP target
       shell: bash
       run: |
         gcloud auth configure-docker --quiet ${{ inputs.target_region }}-docker.pkg.dev
         docker tag ${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }} \
                    ${{ inputs.target_region }}-docker.pkg.dev/${{ inputs.target_gcp_project_id }}/${{ inputs.container_image }}
         docker push ${{ inputs.target_region }}-docker.pkg.dev/${{ inputs.target_gcp_project_id }}/${{ inputs.container_image }}
-      if: ${{ inputs.target_registry == 'gcp' }}
+      if: ${{ inputs.target_registry == 'gcp' && inputs.source_registry == 'gcp' }}
+    - name: Configure AWS credentials for target
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.target_aws_role_arn }}
+        aws-region: ${{ inputs.target_region }}
+      if: ${{ inputs.target_registry == 'aws' }}
+    - name: Push image to AWS ECR target
+      shell: bash
+      run: |
+        # Login to ECR
+        aws ecr get-login-password --region ${{ inputs.target_region }} | \
+          docker login --username AWS --password-stdin ${{ inputs.target_aws_account_id }}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com
+
+        # Ensure repository exists
+        REPO_NAME="${{ inputs.container_image }}"
+        REPO_NAME="${REPO_NAME%%:*}"
+        ${{ github.action_path }}/scripts/ecr-ensure-repository.sh "${REPO_NAME}" "${{ inputs.target_region }}"
+
+        # Determine source image based on source registry
+        if [[ "${{ inputs.source_registry }}" == "gcp" ]]; then
+          SOURCE_IMAGE="${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }}"
+        elif [[ "${{ inputs.source_registry }}" == "aws" ]]; then
+          SOURCE_IMAGE="${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
+        fi
+
+        # Tag and push
+        TARGET_IMAGE="${{ inputs.target_aws_account_id }}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com/${{ inputs.container_image }}"
+        docker tag "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
+        docker push "${TARGET_IMAGE}"
+      if: ${{ inputs.target_registry == 'aws' }}

--- a/docs/CODESTYLE.md
+++ b/docs/CODESTYLE.md
@@ -19,12 +19,56 @@ yamllint action.yml .github/
 
 ## Shell Scripts
 
+### Standalone Scripts
+
+Shell scripts in the `scripts/` directory should follow these guidelines:
+
+- Use `#!/usr/bin/env bash` shebang
+- Enable strict mode: `set -euo pipefail`
+- Use `readonly` for constants
+- Include usage documentation in comments at the top of the script
+- Use meaningful function and variable names
+- Log messages should include the script name for traceability
+- Exit with appropriate status codes (0 for success, non-zero for errors)
+
+Example structure:
+
+```bash
+#!/usr/bin/env bash
+#
+# Script description here.
+#
+# Usage: script-name.sh <arg1> <arg2>
+#
+
+set -euo pipefail
+
+readonly SCRIPT_NAME="$(basename "${0}")"
+
+log_info() {
+    echo "[INFO] ${SCRIPT_NAME}: ${1}"
+}
+
+log_error() {
+    echo "[ERROR] ${SCRIPT_NAME}: ${1}" >&2
+}
+
+main() {
+    # Implementation
+}
+
+main "${@}"
+```
+
+### Embedded Scripts in action.yml
+
 The action contains embedded shell scripts in `action.yml`. Follow these guidelines:
 
 - Use double quotes for variable expansion
 - Check required variables with explicit error messages
 - Exit with non-zero status on errors
 - Use meaningful variable names
+- Add comments for complex logic
 
 ## Commit Messages
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,25 +2,33 @@
 
 ## Distribute a Container Image
 
-This GitHub Action copies a container image to multiple registries.
+This GitHub Action copies a container image to multiple registries. Supports GCP Artifact Registry and AWS ECR.
 
 ## Inputs
 
-| Name                                | Description                                                                  | Required | Default |
-| ----------------------------------- | ---------------------------------------------------------------------------- | -------- | ------- |
-| `source_registry`                   | Source registry                                                              | true     |         |
-| `source_workload_identity_provider` | Workload Identity Provider                                                   | false    |         |
-| `source_service_account`            | Service Account                                                              | false    |         |
-| `source_region`                     | Region to pull the container from. Valid values: Google Cloud or AWS regions | false    | ""      |
-| `source_gcp_project_id`             | Google Cloud Project ID                                                      | false    | ""      |
-| `target_registry`                   | Target registry                                                              | true     |         |
-| `target_workload_identity_provider` | Workload Identity Provider                                                   | false    |         |
-| `target_service_account`            | Service Account                                                              | false    |         |
-| `target_region`                     | Region to push the container to. Valid values: Google Cloud or AWS regions   | false    | ""      |
-| `target_gcp_project_id`             | Google Cloud Project ID                                                      | false    | ""      |
-| `container_image`                   | Container image in the format: `[namespace]/[name]:[tag]`                    | true     |         |
+| Name                                | Description                                                                   | Required | Default |
+| ----------------------------------- | ----------------------------------------------------------------------------- | -------- | ------- |
+| `source_registry`                   | Source registry (`gcp` or `aws`)                                              | true     |         |
+| `source_workload_identity_provider` | GCP Workload Identity Provider                                                | false    |         |
+| `source_service_account`            | GCP Service Account                                                           | false    |         |
+| `source_region`                     | Region to pull the container from. Valid values: Google Cloud or AWS regions  | false    | ""      |
+| `source_gcp_project_id`             | Google Cloud Project ID                                                       | false    | ""      |
+| `source_aws_account_id`             | AWS Account ID                                                                | false    | ""      |
+| `source_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication                                      | false    | ""      |
+| `target_registry`                   | Target registry (`gcp` or `aws`)                                              | true     |         |
+| `target_workload_identity_provider` | GCP Workload Identity Provider                                                | false    |         |
+| `target_service_account`            | GCP Service Account                                                           | false    |         |
+| `target_region`                     | Region to push the container to. Valid values: Google Cloud or AWS regions    | false    | ""      |
+| `target_gcp_project_id`             | Google Cloud Project ID                                                       | false    | ""      |
+| `target_aws_account_id`             | AWS Account ID                                                                | false    | ""      |
+| `target_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication                                      | false    | ""      |
+| `container_image`                   | Container image in the format: `[namespace]/[name]:[tag]`                     | true     |         |
 
-## Usage
+## Usage Examples
+
+### GCP to GCP
+
+Copy a container image between GCP Artifact Registry instances:
 
 ```yaml
 name: Distribute Container Image
@@ -30,9 +38,12 @@ on: [push]
 jobs:
     distribute:
         runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Distribute container image
               uses: martoc/action-container-distribute@v1
@@ -48,4 +59,121 @@ jobs:
                   target_region: "europe-west1"
                   target_gcp_project_id: "target-project-id"
                   container_image: "namespace/image:tag"
+```
+
+### GCP to AWS ECR
+
+Copy a container image from GCP Artifact Registry to AWS ECR:
+
+```yaml
+name: Distribute Container Image to AWS
+
+on: [push]
+
+jobs:
+    distribute:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Distribute container image
+              uses: martoc/action-container-distribute@v1
+              with:
+                  source_registry: "gcp"
+                  source_workload_identity_provider: "projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
+                  source_service_account: "source-service-account@project-id.iam.gserviceaccount.com"
+                  source_region: "europe-west2"
+                  source_gcp_project_id: "source-project-id"
+                  target_registry: "aws"
+                  target_aws_role_arn: "arn:aws:iam::123456789012:role/github-actions-role"
+                  target_region: "eu-west-1"
+                  target_aws_account_id: "123456789012"
+                  container_image: "namespace/image:tag"
+```
+
+### AWS ECR to AWS ECR
+
+Copy a container image between AWS ECR registries:
+
+```yaml
+name: Distribute Container Image between AWS regions
+
+on: [push]
+
+jobs:
+    distribute:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Distribute container image
+              uses: martoc/action-container-distribute@v1
+              with:
+                  source_registry: "aws"
+                  source_aws_role_arn: "arn:aws:iam::123456789012:role/github-actions-role"
+                  source_region: "us-east-1"
+                  source_aws_account_id: "123456789012"
+                  target_registry: "aws"
+                  target_aws_role_arn: "arn:aws:iam::987654321098:role/github-actions-role"
+                  target_region: "eu-west-1"
+                  target_aws_account_id: "987654321098"
+                  container_image: "my-app:v1.0.0"
+```
+
+## AWS ECR Repository Auto-Creation
+
+When pushing to AWS ECR, the action automatically creates the repository if it does not exist. This is handled by the `scripts/ecr-ensure-repository.sh` script.
+
+## Authentication
+
+### GCP Authentication
+
+The action uses GCP Workload Identity Federation for authentication. Ensure your GitHub Actions workflow has the required permissions:
+
+```yaml
+permissions:
+    id-token: write
+    contents: read
+```
+
+### AWS Authentication
+
+The action uses AWS OIDC authentication with IAM role assumption. Configure your AWS IAM role to trust GitHub's OIDC provider:
+
+1. Create an IAM OIDC identity provider for GitHub Actions
+2. Create an IAM role with the required ECR permissions
+3. Configure the trust policy to allow your repository to assume the role
+
+Required IAM permissions for ECR:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:CreateRepository"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
 ```

--- a/scripts/ecr-ensure-repository.sh
+++ b/scripts/ecr-ensure-repository.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Ensures an ECR repository exists, creating it if necessary.
+#
+# Usage: ecr-ensure-repository.sh <repository-name> <region> [image-tag-mutability]
+#
+# Arguments:
+#   repository-name      Name of the ECR repository (required)
+#   region               AWS region (required)
+#   image-tag-mutability MUTABLE or IMMUTABLE (default: MUTABLE)
+#
+# Environment variables:
+#   AWS credentials must be configured (via OIDC, environment variables, or AWS CLI profile)
+#
+# Exit codes:
+#   0 - Repository exists or was created successfully
+#   1 - Error occurred
+#
+
+set -euo pipefail
+
+readonly SCRIPT_NAME="$(basename "${0}")"
+
+log_info() {
+    echo "[INFO] ${SCRIPT_NAME}: ${1}"
+}
+
+log_error() {
+    echo "[ERROR] ${SCRIPT_NAME}: ${1}" >&2
+}
+
+usage() {
+    echo "Usage: ${SCRIPT_NAME} <repository-name> <region> [image-tag-mutability]"
+    echo ""
+    echo "Arguments:"
+    echo "  repository-name      Name of the ECR repository (required)"
+    echo "  region               AWS region (required)"
+    echo "  image-tag-mutability MUTABLE or IMMUTABLE (default: MUTABLE)"
+    exit 1
+}
+
+ensure_repository() {
+    local repository_name="${1}"
+    local region="${2}"
+    local image_tag_mutability="${3:-MUTABLE}"
+
+    # Validate inputs
+    if [[ -z "${repository_name}" ]]; then
+        log_error "Repository name is required"
+        usage
+    fi
+
+    if [[ -z "${region}" ]]; then
+        log_error "Region is required"
+        usage
+    fi
+
+    # Check if repository exists
+    log_info "Checking if repository '${repository_name}' exists in region '${region}'..."
+
+    if aws ecr describe-repositories \
+        --repository-names "${repository_name}" \
+        --region "${region}" \
+        --output text \
+        >/dev/null 2>&1; then
+        log_info "Repository '${repository_name}' already exists"
+        return 0
+    fi
+
+    # Create repository
+    log_info "Creating repository '${repository_name}' in region '${region}'..."
+
+    if aws ecr create-repository \
+        --repository-name "${repository_name}" \
+        --region "${region}" \
+        --image-tag-mutability "${image_tag_mutability}" \
+        --output text \
+        >/dev/null; then
+        log_info "Repository '${repository_name}' created successfully"
+        return 0
+    else
+        log_error "Failed to create repository '${repository_name}'"
+        return 1
+    fi
+}
+
+main() {
+    if [[ $# -lt 2 ]]; then
+        log_error "Missing required arguments"
+        usage
+    fi
+
+    ensure_repository "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
## Summary

- Add AWS ECR as a supported registry for both source and target
- Implement OIDC authentication using `aws-actions/configure-aws-credentials@v4`
- Add automatic ECR repository creation via `scripts/ecr-ensure-repository.sh`
- Support GCP to AWS ECR migration workflow

## Test plan

- [ ] Test GCP to GCP distribution (existing functionality)
- [ ] Test GCP to AWS ECR distribution
- [ ] Test AWS ECR to AWS ECR distribution
- [ ] Verify ECR repository auto-creation works correctly
- [ ] Verify OIDC authentication with IAM role assumption