### PR TITLE
feat: extract AWS account ID from role ARN automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ A GitHub Action that copies container images between registries. Supports GCP Ar
     target_registry: aws
     target_aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
     target_region: eu-west-1
-    target_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
     container_image: namespace/image:tag
 ```
 
@@ -66,15 +65,13 @@ A GitHub Action that copies container images between registries. Supports GCP Ar
 | `source_service_account` | GCP Service Account | No |
 | `source_region` | Source region | No |
 | `source_gcp_project_id` | Source GCP Project ID | No |
-| `source_aws_account_id` | Source AWS Account ID | No |
-| `source_aws_role_arn` | Source AWS IAM Role ARN for OIDC | No |
+| `source_aws_role_arn` | Source AWS IAM Role ARN for OIDC (account ID extracted automatically) | No |
 | `target_registry` | Target registry (`gcp` or `aws`) | Yes |
 | `target_workload_identity_provider` | GCP Workload Identity Provider | No |
 | `target_service_account` | GCP Service Account | No |
 | `target_region` | Target region | No |
 | `target_gcp_project_id` | Target GCP Project ID | No |
-| `target_aws_account_id` | Target AWS Account ID | No |
-| `target_aws_role_arn` | Target AWS IAM Role ARN for OIDC | No |
+| `target_aws_role_arn` | Target AWS IAM Role ARN for OIDC (account ID extracted automatically) | No |
 | `container_image` | Container image in format `[namespace]/[name]:[tag]` | Yes |
 
 ## Licence

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,11 @@ runs:
       shell: bash
       run: |
         SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
+        if [[ -z "${SOURCE_AWS_ACCOUNT_ID}" ]]; then
+          echo "Error: Failed to extract AWS account ID from source_aws_role_arn ('${{ inputs.source_aws_role_arn }}')." >&2
+          echo "Please ensure it is a valid IAM role ARN, e.g., arn:aws:iam::<account-id>:role/<role-name>." >&2
+          exit 1
+        fi
         aws ecr get-login-password --region ${{ inputs.source_region }} | \
           docker login --username AWS --password-stdin "${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com"
         docker pull "${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
@@ -108,9 +113,13 @@ runs:
     - name: Push image to AWS ECR target
       shell: bash
       run: |
-        # Extract account IDs from role ARNs
+        # Extract and validate target account ID from role ARN
         TARGET_AWS_ACCOUNT_ID=$(echo "${{ inputs.target_aws_role_arn }}" | cut -d':' -f5)
-        SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
+        if [[ -z "${TARGET_AWS_ACCOUNT_ID}" ]]; then
+          echo "Error: Failed to extract AWS account ID from target_aws_role_arn ('${{ inputs.target_aws_role_arn }}')." >&2
+          echo "Please ensure it is a valid IAM role ARN, e.g., arn:aws:iam::<account-id>:role/<role-name>." >&2
+          exit 1
+        fi
 
         # Login to ECR
         aws ecr get-login-password --region ${{ inputs.target_region }} | \
@@ -125,6 +134,7 @@ runs:
         if [[ "${{ inputs.source_registry }}" == "gcp" ]]; then
           SOURCE_IMAGE="${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }}"
         elif [[ "${{ inputs.source_registry }}" == "aws" ]]; then
+          SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
           SOURCE_IMAGE="${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: "Google Cloud Project ID"
     required: false
     default: ""
-  source_aws_account_id:
-    description: "AWS Account ID"
-    required: false
-    default: ""
   source_aws_role_arn:
     description: "AWS IAM Role ARN for OIDC authentication"
     required: false
@@ -48,10 +44,6 @@ inputs:
     default: ""
   target_gcp_project_id:
     description: "Google Cloud Project ID"
-    required: false
-    default: ""
-  target_aws_account_id:
-    description: "AWS Account ID"
     required: false
     default: ""
   target_aws_role_arn:
@@ -89,9 +81,10 @@ runs:
     - name: Pull image from AWS ECR source
       shell: bash
       run: |
+        SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
         aws ecr get-login-password --region ${{ inputs.source_region }} | \
-          docker login --username AWS --password-stdin ${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com
-        docker pull ${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}
+          docker login --username AWS --password-stdin "${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com"
+        docker pull "${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
       if: ${{ inputs.source_registry == 'aws' }}
     - uses: google-github-actions/auth@v2
       with:
@@ -115,9 +108,13 @@ runs:
     - name: Push image to AWS ECR target
       shell: bash
       run: |
+        # Extract account IDs from role ARNs
+        TARGET_AWS_ACCOUNT_ID=$(echo "${{ inputs.target_aws_role_arn }}" | cut -d':' -f5)
+        SOURCE_AWS_ACCOUNT_ID=$(echo "${{ inputs.source_aws_role_arn }}" | cut -d':' -f5)
+
         # Login to ECR
         aws ecr get-login-password --region ${{ inputs.target_region }} | \
-          docker login --username AWS --password-stdin ${{ inputs.target_aws_account_id }}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com
+          docker login --username AWS --password-stdin "${TARGET_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com"
 
         # Ensure repository exists
         REPO_NAME="${{ inputs.container_image }}"
@@ -128,11 +125,11 @@ runs:
         if [[ "${{ inputs.source_registry }}" == "gcp" ]]; then
           SOURCE_IMAGE="${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }}"
         elif [[ "${{ inputs.source_registry }}" == "aws" ]]; then
-          SOURCE_IMAGE="${{ inputs.source_aws_account_id }}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
+          SOURCE_IMAGE="${SOURCE_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.source_region }}.amazonaws.com/${{ inputs.container_image }}"
         fi
 
         # Tag and push
-        TARGET_IMAGE="${{ inputs.target_aws_account_id }}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com/${{ inputs.container_image }}"
+        TARGET_IMAGE="${TARGET_AWS_ACCOUNT_ID}.dkr.ecr.${{ inputs.target_region }}.amazonaws.com/${{ inputs.container_image }}"
         docker tag "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
         docker push "${TARGET_IMAGE}"
       if: ${{ inputs.target_registry == 'aws' }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,15 +13,13 @@ This GitHub Action copies a container image to multiple registries. Supports GCP
 | `source_service_account`            | GCP Service Account                                                           | false    |         |
 | `source_region`                     | Region to pull the container from. Valid values: Google Cloud or AWS regions  | false    | ""      |
 | `source_gcp_project_id`             | Google Cloud Project ID                                                       | false    | ""      |
-| `source_aws_account_id`             | AWS Account ID                                                                | false    | ""      |
-| `source_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication                                      | false    | ""      |
+| `source_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication (account ID extracted automatically) | false    | ""      |
 | `target_registry`                   | Target registry (`gcp` or `aws`)                                              | true     |         |
 | `target_workload_identity_provider` | GCP Workload Identity Provider                                                | false    |         |
 | `target_service_account`            | GCP Service Account                                                           | false    |         |
 | `target_region`                     | Region to push the container to. Valid values: Google Cloud or AWS regions    | false    | ""      |
 | `target_gcp_project_id`             | Google Cloud Project ID                                                       | false    | ""      |
-| `target_aws_account_id`             | AWS Account ID                                                                | false    | ""      |
-| `target_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication                                      | false    | ""      |
+| `target_aws_role_arn`               | AWS IAM Role ARN for OIDC authentication (account ID extracted automatically) | false    | ""      |
 | `container_image`                   | Container image in the format: `[namespace]/[name]:[tag]`                     | true     |         |
 
 ## Usage Examples
@@ -91,7 +89,6 @@ jobs:
                   target_registry: "aws"
                   target_aws_role_arn: "arn:aws:iam::123456789012:role/github-actions-role"
                   target_region: "eu-west-1"
-                  target_aws_account_id: "123456789012"
                   container_image: "namespace/image:tag"
 ```
 
@@ -120,11 +117,9 @@ jobs:
                   source_registry: "aws"
                   source_aws_role_arn: "arn:aws:iam::123456789012:role/github-actions-role"
                   source_region: "us-east-1"
-                  source_aws_account_id: "123456789012"
                   target_registry: "aws"
                   target_aws_role_arn: "arn:aws:iam::987654321098:role/github-actions-role"
                   target_region: "eu-west-1"
-                  target_aws_account_id: "987654321098"
                   container_image: "my-app:v1.0.0"
 ```
 


### PR DESCRIPTION
## Summary

- Remove `source_aws_account_id` and `target_aws_account_id` input parameters from the action
- Extract AWS account ID automatically from the role ARN using the format `arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME`
- Update documentation to reflect the simplified configuration

## Test plan

- [ ] Verify GCP to AWS ECR transfer works correctly with account ID extracted from role ARN
- [ ] Verify AWS ECR to AWS ECR transfer works correctly with account IDs extracted from role ARNs
- [ ] Confirm backward compatibility is not required (breaking change is acceptable for unreleased feature)