### PR TITLE
fix: upgrade actions to versions supporting Node 24

### DIFF
--- a/.github/integration-tests.yml
+++ b/.github/integration-tests.yml
@@ -16,7 +16,7 @@
         id-token: write
       runs-on: ubuntu-24.04
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
           fetch-tags: true
@@ -35,7 +35,7 @@
         id-token: write
       runs-on: ubuntu-24.04
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
           fetch-tags: true
@@ -44,7 +44,7 @@
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -62,7 +62,7 @@
         id-token: write
       runs-on: ubuntu-24.04
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
           fetch-tags: true

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         docker pull ${{ inputs.source_region }}-docker.pkg.dev/${{ inputs.source_gcp_project_id }}/${{ inputs.container_image }}
       if: ${{ inputs.source_registry == 'gcp' }}
     - name: Configure AWS credentials for source
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.source_aws_role_arn }}
         aws-region: ${{ inputs.source_region }}
@@ -105,7 +105,7 @@ runs:
         docker push ${{ inputs.target_region }}-docker.pkg.dev/${{ inputs.target_gcp_project_id }}/${{ inputs.container_image }}
       if: ${{ inputs.target_registry == 'gcp' && inputs.source_registry == 'gcp' }}
     - name: Configure AWS credentials for target
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.target_aws_role_arn }}
         aws-region: ${{ inputs.target_region }}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -41,7 +41,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Distribute container image
               uses: martoc/action-container-distribute@v1
@@ -76,7 +76,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Distribute container image
               uses: martoc/action-container-distribute@v1
@@ -109,7 +109,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Distribute container image
               uses: martoc/action-container-distribute@v1


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 in `docs/USAGE.md` and `.github/integration-tests.yml`
- Bump `aws-actions/configure-aws-credentials` v4 → v6 in `action.yml` and `.github/integration-tests.yml`

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026. The bumped versions run on Node.js 24 by default.

## Test plan

- [ ] CI checks pass
- [ ] Integration tests run cleanly against the new action versions
